### PR TITLE
license: update fsf address

### DIFF
--- a/nova-tt/dummy_mutex.hpp
+++ b/nova-tt/dummy_mutex.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file dummy_mutex.hpp */
 

--- a/nova-tt/mlock.hpp
+++ b/nova-tt/mlock.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file mlock.hpp */
 

--- a/nova-tt/name_thread.hpp
+++ b/nova-tt/name_thread.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file mlock.hpp */
 

--- a/nova-tt/nanosleep.hpp
+++ b/nova-tt/nanosleep.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file nanosleep.hpp */
 /** \namespace nova */

--- a/nova-tt/pause.hpp
+++ b/nova-tt/pause.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file spin_lock.hpp */
 

--- a/nova-tt/physical_concurrency.hpp
+++ b/nova-tt/physical_concurrency.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_PHYSICAL_CONCURRENCT_HPP
 #define NOVA_TT_PHYSICAL_CONCURRENCT_HPP

--- a/nova-tt/rw_mutex.hpp
+++ b/nova-tt/rw_mutex.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file rw_mutex.hpp */
 

--- a/nova-tt/rw_spinlock.hpp
+++ b/nova-tt/rw_spinlock.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file rw_spinlock.hpp */
 

--- a/nova-tt/semaphore.hpp
+++ b/nova-tt/semaphore.hpp
@@ -15,8 +15,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file semaphore.hpp */
 

--- a/nova-tt/semaphore_boost_fallback.hpp
+++ b/nova-tt/semaphore_boost_fallback.hpp
@@ -15,8 +15,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_SEMAPHORE_BOOST_FALLBACK_HPP
 #define NOVA_TT_SEMAPHORE_BOOST_FALLBACK_HPP

--- a/nova-tt/semaphore_dispatch.hpp
+++ b/nova-tt/semaphore_dispatch.hpp
@@ -15,8 +15,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_SEMAPHORE_DISPATCH_HPP
 #define NOVA_TT_SEMAPHORE_DISPATCH_HPP

--- a/nova-tt/semaphore_mach.hpp
+++ b/nova-tt/semaphore_mach.hpp
@@ -15,8 +15,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_SEMAPHORE_MACH_HPP
 #define NOVA_TT_SEMAPHORE_MACH_HPP

--- a/nova-tt/semaphore_posix.hpp
+++ b/nova-tt/semaphore_posix.hpp
@@ -15,8 +15,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_SEMAPHORE_POSIX_HPP
 #define NOVA_TT_SEMAPHORE_POSIX_HPP

--- a/nova-tt/semaphore_pthreads.hpp
+++ b/nova-tt/semaphore_pthreads.hpp
@@ -15,8 +15,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_SEMAPHORE_PTHREADS_HPP
 #define NOVA_TT_SEMAPHORE_PTHREADS_HPP

--- a/nova-tt/semaphore_win32.hpp
+++ b/nova-tt/semaphore_win32.hpp
@@ -15,8 +15,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_SEMAPHORE_WIN32_HPP
 #define NOVA_TT_SEMAPHORE_WIN32_HPP

--- a/nova-tt/spin_lock.hpp
+++ b/nova-tt/spin_lock.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file spin_lock.hpp */
 

--- a/nova-tt/thread_affinity.hpp
+++ b/nova-tt/thread_affinity.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 /** \file thread_affinity.hpp */
 

--- a/nova-tt/thread_pool.hpp
+++ b/nova-tt/thread_pool.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef THREAD_POOL_HPP
 #define THREAD_POOL_HPP

--- a/nova-tt/thread_priority.hpp
+++ b/nova-tt/thread_priority.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_THREAD_PRITORITY_HPP
 #define NOVA_TT_THREAD_PRITORITY_HPP

--- a/nova-tt/thread_priority_fallback.hpp
+++ b/nova-tt/thread_priority_fallback.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_THREAD_PRITORITY_FALLBACK_HPP
 #define NOVA_TT_THREAD_PRITORITY_FALLBACK_HPP

--- a/nova-tt/thread_priority_mach.hpp
+++ b/nova-tt/thread_priority_mach.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_THREAD_PRITORITY_MACH_HPP
 #define NOVA_TT_THREAD_PRITORITY_MACH_HPP

--- a/nova-tt/thread_priority_pthread.hpp
+++ b/nova-tt/thread_priority_pthread.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_THREAD_PRITORITY_PTHREAD_HPP
 #define NOVA_TT_THREAD_PRITORITY_PTHREAD_HPP

--- a/nova-tt/thread_priority_win32.hpp
+++ b/nova-tt/thread_priority_win32.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_TT_THREAD_PRITORITY_WIN32_HPP
 #define NOVA_TT_THREAD_PRITORITY_WIN32_HPP


### PR DESCRIPTION
License headers are using the old FSF address and this is causing
packaging error with rpmlint: incorrect-fsf-address.