### PR TITLE
fix implementation of pause() function

### DIFF
--- a/nova-tt/pause.hpp
+++ b/nova-tt/pause.hpp
@@ -21,33 +21,51 @@
 #ifndef NOVA_TT_PAUSE_HPP
 #define NOVA_TT_PAUSE_HPP
 
-#ifdef __SSE2__
-#include <emmintrin.h>
+#if defined(_MSC_VER)
+#include <Windows.h>
+#elif defined(__x86_64__) || defined(__SSE2__)
+/* amd64 resp. SSE2 */
+#define NOVA_TT_USE_MM_PAUSE
+#include <immintrin.h>
+#elif defined(__i386__) && defined(__GNUC__)
+#define NOVA_TT_USE_REP_NOP
+#elif defined(__aarch64__) && defined(__GNUC__)
+/* ARM64 */
+#define NOVA_TT_USE_ARM_ISB
+#elif defined(__arm__) && defined(__GNUC__) && \
+    (defined(__ARM_ARCH_6K__) || \
+    defined(__ARM_ARCH_6Z__) || \
+    defined(__ARM_ARCH_6ZK__) || \
+    defined(__ARM_ARCH_6T2__) || \
+    defined(__ARM_ARCH_7__) || \
+    defined(__ARM_ARCH_7A__) || \
+    defined(__ARM_ARCH_7R__) || \
+    defined(__ARM_ARCH_7M__) || \
+    defined(__ARM_ARCH_7S__) || \
+    defined(__ARM_ARCH_8A__))
+/* mnemonic 'yield' is supported from ARMv6k onwards */
+#define NOVA_TT_USE_ARM_YIELD
+#else /* fall back to busy-waiting */
+#warning "Cannot pause CPU, falling back to busy-waiting."
 #endif
 
 namespace nova   {
 namespace detail {
 
-#ifdef __SSE2__
-
 static inline void pause()
 {
+#if defined(_MSC_VER)
+	YieldProcessor(); /* expands to pause/yield instruction */
+#elif defined(NOVA_TT_USE_MM_PAUSE)
 	_mm_pause();
-}
-
-#elif defined(__GNUC__) && ( defined(__i386__) || defined(__x86_64__) )
-
-static inline void pause()
-{
+#elif defined(NOVA_TT_USE_REP_NOP)
 	__asm__ __volatile__( "rep; nop" : : : "memory" );
-}
-
-#else
-
-static inline void pause()
-{}
-
+#elif defined(NOVA_TT_USE_ARM_ISB)
+	__asm__ __volatile__("isb");
+#elif defined(NOVA_TT_USE_ARM_YIELD)
+	__asm__ __volatile__("yield");
 #endif
+}
 
 }}
 


### PR DESCRIPTION
- use _mm_pause() on all Intel platforms
- use "yield" mnemonic on ARM
- fallback to thread yielding otherwise

In 2024 we shouldn't need to check for SSE2 support anymore.

This fixes issues such as https://github.com/supercollider/supercollider/issues/5899#issuecomment-2248064013

I'm not sure about the thread yielding fallback. Maybe it's better to do nothing and just burn CPU cycles? Either way, we should print a warning.